### PR TITLE
Set up Rodan development stack as default stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 rodan/Rodan
 rodan-client/rodan-client
 var
+*.pyc
+__pycache__

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Build Rodan docker images from zero.
 
+Default `docker-compose.yml` sets up dev environment.
+
+`docker-compose.prod.yml` sets up prod environment.
+
 
 ## Background
 
@@ -9,28 +13,37 @@ Build Rodan docker images from zero.
 
 A Rodan installation includes one Django server for backend APIs, several Celery workers and one frontend app server.
 
+The dev environment only sets up backend API and frontend server, running Celery tasks in "eager" mode in server process.
+
 
 ## Steps to follow
 
 1. Install Docker CE (community edition) and docker-compose onto your system.
 
-2. Put your Rodan repo into `./rodan/Rodan`. For example:
+2. Fork studio-theyang/Rodan, clone your fork into `./rodan/Rodan`, and add studio-theyang/Rodan as upstream:
 
 ````
-cd rodan; git clone git@github.com:studio-theyang/Rodan.git
+cd rodan
+git clone git@github.com:yourgithubname/Rodan.git
+cd Rodan
+git remote add upstream git@github.com:studio-theyang/Rodan.git
 ````
 
-3. Put your rodan-client repo into `./rodan-client/rodan-client`. For example:
+3. Fork studio-theyang/rodan-client, clone your fork into `./rodan-client/rodan-client`, and add studio-theyang/rodan-client as upstream:
 
 ````
-cd rodan-client; git clone git@github.com:studio-theyang/rodan-client.git
+cd rodan-client
+git clone git@github.com:yourgithubname/rodan-client.git
+cd rodan-client
+git remote add upstream git@github.com:studio-theyang/rodan-client.git
 ````
 
-4. Run `docker-compose build`.
+4. Run `docker-compose build`. (To build prod environment, run `docker-compose -f docker-compose.prod.yml build`)
 
-5. Run `docker-compose up`.
+5. Run `docker-compose up`. (To launch prod environment, run `docker-compose -f docker-compose.prod.yml up`)
 
 6. Wait until things set up. If successful, the server is available at `http://localhost:8080` and the client at `http://localhost:8081`.
+
 
 ## Storage
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,187 @@
+version: "3"
+services:
+  nginx:
+    build: ./nginx
+    container_name: nginx
+    depends_on:
+      - rodan-server
+      - rodan-websocket
+      - rodan-client
+    ports:
+      - "8080:80"  # Final port exposed to host
+    restart: always
+    volumes:
+      - rodan_static:/var/www/static
+      - unix_socket:/var/run/unix_socket
+  rodan-client:
+    build:
+      context: ./rodan-client
+      args:
+        DEV_JSPM_GITHUB_AUTH_TOKEN: ${DEV_JSPM_GITHUB_AUTH_TOKEN}
+    container_name: rodan-client
+    environment:
+      - RODAN_CLIENT_DEVELOP_HOST=rodan-client
+    ports:
+      - "8081:9002"
+    restart: always
+  rodan-server:
+    build:
+      context: ./rodan
+      args:
+        role: server
+    image: theyang/rodan:dev
+    command: bash -c "./manage.py check && ./manage.py migrate && ENVS=`env` ./manage.py collectstatic --clear --noinput && uwsgi --disable-logging -s /var/run/unix_socket/rodan-server.sock --module rodan.wsgi_django:application"
+    container_name: rodan-server
+    depends_on:
+      - rabbitmq
+      - redis
+      - postgres
+    environment:
+      - DJANGO_ADMIN_URL=django_admin
+      - DJANGO_DEBUG_MODE=${DEBUG}
+      - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
+      - POSTGRES_DB=${RODAN_POSTGRES_DB}
+      - POSTGRES_USER=${RODAN_POSTGRES_USER}
+      - POSTGRES_PASSWORD=${RODAN_POSTGRES_PASSWORD}
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
+      - RODAN_PSQL_SUPERUSER_USERNAME=${RODAN_POSTGRES_SUPERUSER}
+      - RODAN_PSQL_SUPERUSER_PASSWORD=${RODAN_POSTGRES_SUPERUSER_PASSWORD}
+      - DJANGO_MEDIA_ROOT=
+      - DJANGO_ALLOWED_HOSTS=${HOSTNAME}
+      - SSL_COOKIE=False
+      - SSL_COOKIE_DOMAIN=${HOSTNAME}
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_DB=0
+      - RABBITMQ_URL=amqp://${RODAN_AMQP_USER}:${RODAN_AMQP_PASSWORD}@rabbitmq:5672/${RODAN_AMQP_VHOST}
+      - CELERY_JOB_QUEUE=${CELERY_JOB_QUEUE}
+    networks:
+      - internal_rodan
+    restart: always
+    volumes:
+      - ./rodan/Rodan:/srv/Rodan
+      - ./var/log:/code/Rodan
+      - rodan_static:/srv/Rodan/staticfiles
+      - rodan_static2:/srv/Rodan/rodan/static
+      - unix_socket:/var/run/unix_socket
+      - ./var/projects:/srv/Rodan/projects
+  rodan-websocket:
+    image: theyang/rodan:dev
+    command: uwsgi --disable-logging -s /var/run/unix_socket/rodan-websocket.sock --module rodan.wsgi_websocket:application
+    container_name: rodan-websocket
+    depends_on:
+      - rodan-server
+      - rabbitmq
+      - redis
+      - postgres
+    environment:
+      - DJANGO_ADMIN_URL=django_admin
+      - DJANGO_DEBUG_MODE=${DEBUG}
+      - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
+      - POSTGRES_DB=${RODAN_POSTGRES_DB}
+      - POSTGRES_USER=${RODAN_POSTGRES_USER}
+      - POSTGRES_PASSWORD=${RODAN_POSTGRES_PASSWORD}
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
+      - RODAN_PSQL_SUPERUSER_USERNAME=${RODAN_POSTGRES_SUPERUSER}
+      - RODAN_PSQL_SUPERUSER_PASSWORD=${RODAN_POSTGRES_SUPERUSER_PASSWORD}
+      - DJANGO_MEDIA_ROOT=
+      - DJANGO_ALLOWED_HOSTS=${HOSTNAME}
+      - SSL_COOKIE=False
+      - SSL_COOKIE_DOMAIN=${HOSTNAME}
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_DB=0
+      - RABBITMQ_URL=amqp://${RODAN_AMQP_USER}:${RODAN_AMQP_PASSWORD}@rabbitmq:5672/${RODAN_AMQP_VHOST}
+    networks:
+      - internal_rodan
+    restart: always
+    volumes:
+      - ./rodan/Rodan:/srv/Rodan
+      - ./var/log:/code/Rodan
+      - rodan_static:/srv/Rodan/staticfiles
+      - rodan_static2:/srv/Rodan/rodan/static
+      - unix_socket:/var/run/unix_socket
+      - ./var/projects:/srv/Rodan/projects
+  rodan-worker:
+    image: theyang/rodan:dev
+    container_name: rodan-worker
+    command: celery -A rodan worker -l DEBUG
+    depends_on:
+      - rabbitmq
+      - postgres
+    environment:
+      - C_FORCE_ROOT=true
+      - DJANGO_ADMIN_URL=django_admin
+      - DJANGO_DEBUG_MODE=${DEBUG}
+      - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
+      - POSTGRES_DB=${RODAN_POSTGRES_DB}
+      - POSTGRES_USER=${RODAN_POSTGRES_USER}
+      - POSTGRES_PASSWORD=${RODAN_POSTGRES_PASSWORD}
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
+      - RODAN_PSQL_SUPERUSER_USERNAME=${RODAN_POSTGRES_SUPERUSER}
+      - RODAN_PSQL_SUPERUSER_PASSWORD=${RODAN_POSTGRES_SUPERUSER_PASSWORD}
+      - DJANGO_MEDIA_ROOT=
+      - DJANGO_ALLOWED_HOSTS=${HOSTNAME}
+      - SSL_COOKIE=False
+      - SSL_COOKIE_DOMAIN=${HOSTNAME}
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_DB=0
+      - RABBITMQ_URL=amqp://${RODAN_AMQP_USER}:${RODAN_AMQP_PASSWORD}@rabbitmq:5672/${RODAN_AMQP_VHOST}
+      - CELERY_JOB_QUEUE=${CELERY_JOB_QUEUE}
+    networks:
+      - internal_rodan
+    restart: always
+    volumes:
+      - ./rodan/Rodan:/srv/Rodan
+      - ./var/log:/code/Rodan
+      - rodan_static:/srv/Rodan/staticfiles
+      - rodan_static2:/srv/Rodan/rodan/static
+      - ./var/projects:/srv/Rodan/projects
+  rabbitmq:
+    container_name: rabbitmq
+    environment:
+      - RABBITMQ_DEFAULT_USER=${RODAN_AMQP_USER}
+      - RABBITMQ_DEFAULT_PASS=${RODAN_AMQP_PASSWORD}
+      - RABBITMQ_DEFAULT_VHOST=${RODAN_AMQP_VHOST}
+    expose:
+      - "5672"
+    image: rabbitmq:3.7
+    networks:
+      - internal_rodan
+    restart: always
+  redis:
+    container_name: redis
+    expose:
+      - "6379"
+    image: redis:5.0
+    networks:
+      - internal_rodan
+    restart: always
+  postgres:
+    build: ./postgres
+    container_name: postgres
+    environment:
+      - POSTGRES_USER=${RODAN_POSTGRES_SUPERUSER}
+      - POSTGRES_PASSWORD=${RODAN_POSTGRES_SUPERUSER_PASSWORD}
+      - PGDATA=/var/lib/postgresql/data/rodan
+      - RODAN_POSTGRES_DB=${RODAN_POSTGRES_DB}
+      - RODAN_POSTGRES_USER=${RODAN_POSTGRES_USER}
+      - RODAN_POSTGRES_PASSWORD=${RODAN_POSTGRES_PASSWORD}
+    networks:
+      - internal_rodan
+    restart: always
+    volumes:
+      - ./postgres/init:/docker-entrypoint-initdb.d
+      - ./var/postgres:/var/lib/postgresql/data/rodan
+networks:
+  internal_rodan:
+volumes:
+  rodan_static:
+  rodan_static2:
+  unix_socket:
+  tmp_rodan_client_node_modules:
+  tmp_rodan_client_develop:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,5 @@
 version: "3"
 services:
-  nginx:
-    build: ./nginx
-    container_name: nginx
-    depends_on:
-      - rodan-server
-      - rodan-websocket
-      - rodan-client
-    ports:
-      - "8080:80"  # Final port exposed to host
-    restart: always
-    volumes:
-      - rodan_static:/var/www/static
-      - unix_socket:/var/run/unix_socket
   rodan-client:
     build:
       context: ./rodan-client
@@ -27,15 +14,11 @@ services:
   rodan-server:
     build:
       context: ./rodan
-      args:
-        role: server
-    image: theyang/rodan:dev
-    command: bash -c "./manage.py check && ./manage.py migrate && ENVS=`env` ./manage.py collectstatic --clear --noinput && uwsgi --disable-logging -s /var/run/unix_socket/rodan-server.sock --module rodan.wsgi_django:application"
+    command: bash -c "./manage.py check && ./manage.py migrate && ./manage.py runserver 0.0.0.0:8080"
     container_name: rodan-server
     depends_on:
-      - rabbitmq
-      - redis
       - postgres
+      - redis
     environment:
       - DJANGO_ADMIN_URL=django_admin
       - DJANGO_DEBUG_MODE=${DEBUG}
@@ -58,101 +41,14 @@ services:
       - CELERY_JOB_QUEUE=${CELERY_JOB_QUEUE}
     networks:
       - internal_rodan
+    ports:
+      - "8080:8080"
     restart: always
     volumes:
+      - ./rodan/dev_settings:/dev_settings
       - ./rodan/Rodan:/srv/Rodan
       - ./var/log:/code/Rodan
-      - rodan_static:/srv/Rodan/staticfiles
-      - rodan_static2:/srv/Rodan/rodan/static
-      - unix_socket:/var/run/unix_socket
       - ./var/projects:/srv/Rodan/projects
-  rodan-websocket:
-    image: theyang/rodan:dev
-    command: uwsgi --disable-logging -s /var/run/unix_socket/rodan-websocket.sock --module rodan.wsgi_websocket:application
-    container_name: rodan-websocket
-    depends_on:
-      - rodan-server
-      - rabbitmq
-      - redis
-      - postgres
-    environment:
-      - DJANGO_ADMIN_URL=django_admin
-      - DJANGO_DEBUG_MODE=${DEBUG}
-      - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
-      - POSTGRES_DB=${RODAN_POSTGRES_DB}
-      - POSTGRES_USER=${RODAN_POSTGRES_USER}
-      - POSTGRES_PASSWORD=${RODAN_POSTGRES_PASSWORD}
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PORT=5432
-      - RODAN_PSQL_SUPERUSER_USERNAME=${RODAN_POSTGRES_SUPERUSER}
-      - RODAN_PSQL_SUPERUSER_PASSWORD=${RODAN_POSTGRES_SUPERUSER_PASSWORD}
-      - DJANGO_MEDIA_ROOT=
-      - DJANGO_ALLOWED_HOSTS=${HOSTNAME}
-      - SSL_COOKIE=False
-      - SSL_COOKIE_DOMAIN=${HOSTNAME}
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - REDIS_DB=0
-      - RABBITMQ_URL=amqp://${RODAN_AMQP_USER}:${RODAN_AMQP_PASSWORD}@rabbitmq:5672/${RODAN_AMQP_VHOST}
-    networks:
-      - internal_rodan
-    restart: always
-    volumes:
-      - ./rodan/Rodan:/srv/Rodan
-      - ./var/log:/code/Rodan
-      - rodan_static:/srv/Rodan/staticfiles
-      - rodan_static2:/srv/Rodan/rodan/static
-      - unix_socket:/var/run/unix_socket
-      - ./var/projects:/srv/Rodan/projects
-  rodan-worker:
-    image: theyang/rodan:dev
-    container_name: rodan-worker
-    command: celery -A rodan worker -l DEBUG
-    depends_on:
-      - rabbitmq
-      - postgres
-    environment:
-      - C_FORCE_ROOT=true
-      - DJANGO_ADMIN_URL=django_admin
-      - DJANGO_DEBUG_MODE=${DEBUG}
-      - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
-      - POSTGRES_DB=${RODAN_POSTGRES_DB}
-      - POSTGRES_USER=${RODAN_POSTGRES_USER}
-      - POSTGRES_PASSWORD=${RODAN_POSTGRES_PASSWORD}
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PORT=5432
-      - RODAN_PSQL_SUPERUSER_USERNAME=${RODAN_POSTGRES_SUPERUSER}
-      - RODAN_PSQL_SUPERUSER_PASSWORD=${RODAN_POSTGRES_SUPERUSER_PASSWORD}
-      - DJANGO_MEDIA_ROOT=
-      - DJANGO_ALLOWED_HOSTS=${HOSTNAME}
-      - SSL_COOKIE=False
-      - SSL_COOKIE_DOMAIN=${HOSTNAME}
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - REDIS_DB=0
-      - RABBITMQ_URL=amqp://${RODAN_AMQP_USER}:${RODAN_AMQP_PASSWORD}@rabbitmq:5672/${RODAN_AMQP_VHOST}
-      - CELERY_JOB_QUEUE=${CELERY_JOB_QUEUE}
-    networks:
-      - internal_rodan
-    restart: always
-    volumes:
-      - ./rodan/Rodan:/srv/Rodan
-      - ./var/log:/code/Rodan
-      - rodan_static:/srv/Rodan/staticfiles
-      - rodan_static2:/srv/Rodan/rodan/static
-      - ./var/projects:/srv/Rodan/projects
-  rabbitmq:
-    container_name: rabbitmq
-    environment:
-      - RABBITMQ_DEFAULT_USER=${RODAN_AMQP_USER}
-      - RABBITMQ_DEFAULT_PASS=${RODAN_AMQP_PASSWORD}
-      - RABBITMQ_DEFAULT_VHOST=${RODAN_AMQP_VHOST}
-    expose:
-      - "5672"
-    image: rabbitmq:3.7
-    networks:
-      - internal_rodan
-    restart: always
   redis:
     container_name: redis
     expose:
@@ -160,7 +56,6 @@ services:
     image: redis:5.0
     networks:
       - internal_rodan
-    restart: always
   postgres:
     build: ./postgres
     container_name: postgres
@@ -179,9 +74,3 @@ services:
       - ./var/postgres:/var/lib/postgresql/data/rodan
 networks:
   internal_rodan:
-volumes:
-  rodan_static:
-  rodan_static2:
-  unix_socket:
-  tmp_rodan_client_node_modules:
-  tmp_rodan_client_develop:

--- a/rodan/Dockerfile
+++ b/rodan/Dockerfile
@@ -9,4 +9,16 @@ RUN pip install 'psycopg2>=2.7,<2.7.99' --upgrade
 
 RUN pip install uwsgi
 
+# We want to override a few Django settings, but we don't want to touch the upstream setting.py,
+# so we create this local_settings.py elsewhere and add its directory `dev_settings` to PYTHONPATH
+# so that Django can call `import local_settings` to load it (DJANGO_SETTINGS_MODULE).
+#
+# The mirrored_rodan_settings.py is a symlink to the original settings.py, and we create it
+# because we cannot call `from rodan.settings import *` due to the Celery loading code in
+# `/srv/Rodan/rodan/__init__.py` that gets loaded when Python discovers `rodan.settings`.
+ENV PYTHONPATH /dev_settings:/mirrored_settings:$${PYTHONPATH}
+RUN mkdir /mirrored_settings
+RUN ln -s /srv/Rodan/rodan/settings.py /mirrored_settings/mirrored_rodan_settings.py
+ENV DJANGO_SETTINGS_MODULE local_settings
+
 WORKDIR /srv/Rodan

--- a/rodan/dev_settings/local_settings.py
+++ b/rodan/dev_settings/local_settings.py
@@ -1,0 +1,37 @@
+from mirrored_rodan_settings import *  # noqa
+
+
+RODAN_PYTHON3_JOBS = [
+    "rodan.jobs.helloworld",
+]
+
+# Run Celery task synchronously, instead of sending into queue
+CELERY_ALWAYS_EAGER = True
+# Propagate exceptions in synchronous task running by default
+CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
+
+
+# STOP: don't edit further
+##############################
+
+# Monkey-patch django.setup() so that we won't run into hanging issues with
+# the setup() call in rodan/__init__.py => rodan/celery.py
+import django  # noqa
+import traceback  # noqa
+
+_orig_django_setup = django.setup
+
+
+def _setup_except_celery(*a, **k):
+    """monkey-patch"""
+    stack = traceback.extract_stack()
+    if len(stack) >= 2 and stack[-2][0] == '/srv/Rodan/rodan/celery.py':
+        print("MONKEY-PATCH: called from rodan/celery.py, do nothing")
+        return None
+    else:
+        return _orig_django_setup(*a, **k)
+
+
+# Avoid monkey-patching more than once
+if django.setup.__doc__ != 'monkey-patch':
+    django.setup = _setup_except_celery


### PR DESCRIPTION
## Description

- Move original prod stack into `docker-compose.prod.yml`
- Set up new `docker-compose.yml`
- Load Rodan dev server with local_settings module that can overwrite original settings from Rodan repo.
- Update doc.

## Proof

- `docker-compose build && docker-compose up` should bring up the new development stack.
- The server now starts in development mode, with hot-loading of file changes.
- Modifying `rodan/dev-settings/local_settings.py` triggers dev server update and overwrites the settings in `rodan/Rodan/rodan/settings.py`
- The workflow is now executed in the server process synchronously.