### PR TITLE
Answer yes to all migration questions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   rodan-server:
     build:
       context: ./rodan
-    command: bash -c "./manage.py check && ./manage.py migrate && ./manage.py runserver 0.0.0.0:8080"
+    command: bash -c "./manage.py check && yes | ./manage.py migrate && ./manage.py runserver 0.0.0.0:8080"
     container_name: rodan-server
     depends_on:
       - postgres


### PR DESCRIPTION
Rodan's extension to Django migration contains interactive yes/no
questions to confirm any Job class changes ([refs](https://github.com/DDMAL/Rodan/wiki/Register-Rodan-Jobs-through-migration). This is not desired in a
Docker setup because it is difficult to pass stdin into container.

The brute solution is to pass yes to all questions asked to streamline
the development procedure.

## Proof

1. Edit any attributes of the HelloWorld job (such as author, category, etc.).
2. Re-run `docker-compose up`
3. You should see "yes" answered to migration question(s), and the container is successfully brought up.

## Ticket

https://theyang.planio.com/issues/636