### PR TITLE
Fix misconfigurations that cause test errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
     command: bash -c "./manage.py check && yes | ./manage.py migrate && ./manage.py runserver 0.0.0.0:8080"
     container_name: rodan-server
     depends_on:
+      # Run RabbitMQ to ensure this test doesn't fail:
+      #   test_cancel_retry_redo (Rodan.rodan.test.views.test_workflowrun.WorkflowRunSimpleExecutionTest)
+      - rabbitmq
       - postgres
       - redis
     environment:
@@ -49,6 +52,18 @@ services:
       - ./rodan/Rodan:/srv/Rodan
       - ./var/log:/code/Rodan
       - ./var/projects:/srv/Rodan/projects
+  rabbitmq:
+    container_name: rabbitmq
+    environment:
+      - RABBITMQ_DEFAULT_USER=${RODAN_AMQP_USER}
+      - RABBITMQ_DEFAULT_PASS=${RODAN_AMQP_PASSWORD}
+      - RABBITMQ_DEFAULT_VHOST=${RODAN_AMQP_VHOST}
+    expose:
+      - "5672"
+    image: rabbitmq:3.7
+    networks:
+      - internal_rodan
+    restart: always
   redis:
     container_name: redis
     expose:

--- a/rodan/Dockerfile
+++ b/rodan/Dockerfile
@@ -9,6 +9,9 @@ RUN pip install 'psycopg2>=2.7,<2.7.99' --upgrade
 
 RUN pip install uwsgi
 
+# Fix pybagit permissions (see Rodan .travis.yml)
+RUN chmod -R 755 /usr/local/lib/python2.7/site-packages/pybagit
+
 # We want to override a few Django settings, but we don't want to touch the upstream setting.py,
 # so we create this local_settings.py elsewhere and add its directory `dev_settings` to PYTHONPATH
 # so that Django can call `import local_settings` to load it (DJANGO_SETTINGS_MODULE).

--- a/rodan/dev_settings/local_settings.py
+++ b/rodan/dev_settings/local_settings.py
@@ -10,6 +10,9 @@ CELERY_ALWAYS_EAGER = True
 # Propagate exceptions in synchronous task running by default
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 
+# We won't install gm or kdu_compress in dev environment
+ENABLE_DIVA = False
+
 
 # STOP: don't edit further
 ##############################


### PR DESCRIPTION
Currently, there are 7 Rodan tests throwing errors because of misconfigurations in the dev environment.

To be fixed with ENABLE_DIVA=False:
- test_post_image (Rodan.rodan.test.views.test_resource.ResourceProcessingTestCase)

To be fixed with the presence of RabbitMQ (ideally, the test should use a mock instead of really calling Celery job cancellation):
- test_cancel_retry_redo (Rodan.rodan.test.views.test_workflowrun.WorkflowRunSimpleExecutionTest)

To be fixed with pybagit permissions:
- test_default_ports (Rodan.rodan.test.views.test_resultspackage.ResultsPackageComplexTest)
- test_expire (Rodan.rodan.test.views.test_resultspackage.ResultsPackageComplexTest)
- test_one_port (Rodan.rodan.test.views.test_resultspackage.ResultsPackageComplexTest)
- test_all_ports (Rodan.rodan.test.views.test_resultspackage.ResultsPackageSimpleTest)
- test_one_port (Rodan.rodan.test.views.test_resultspackage.ResultsPackageSimpleTest)

## Proof

In the container, running `./manage.py test` should not give errors on these 7 tests.

(Note: this PR changes Dockerfile, so you'll need to run `docker-compose build` again.)