### PR TITLE
Fix the injection of test job packages

### DIFF
--- a/rodan/dev_settings/local_settings.py
+++ b/rodan/dev_settings/local_settings.py
@@ -1,7 +1,7 @@
 from mirrored_rodan_settings import *  # noqa
 
 
-RODAN_PYTHON3_JOBS = [
+TEST_JOB_PACKAGES = [
     "rodan.jobs.helloworld",
 ]
 
@@ -13,6 +13,11 @@ CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 
 # STOP: don't edit further
 ##############################
+
+# Append TEST_JOB_PACKAGES to RODAN_JOB_PACKAGES
+for job_package in TEST_JOB_PACKAGES:
+    if job_package not in RODAN_JOB_PACKAGES:
+        RODAN_JOB_PACKAGES.append(job_package)
 
 # Monkey-patch django.setup() so that we won't run into hanging issues with
 # the setup() call in rodan/__init__.py => rodan/celery.py


### PR DESCRIPTION
Refs [settings.py](https://github.com/studio-theyang/Rodan/blob/84e11a2e028b41cf34b9d80d8b8d7ec079ef8a3f/rodan/settings.py#L157-L167), it's only useful to modify `settings.RODAN_JOB_PACKAGES`.

Proof: HelloWorld and HelloWorld3 should now appear out of box on http://localhost:8080/jobs/ besides resource_distributor. (you need to restart rodan-server container to apply the job changes during migration.)