### PR TITLE
Use docker volume to load rodan-client source code

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,17 @@ services:
       context: ./rodan-client
       args:
         DEV_JSPM_GITHUB_AUTH_TOKEN: ${DEV_JSPM_GITHUB_AUTH_TOKEN}
+    command: bash -c "cp -f /src/configuration.json /rodan-client/configuration.json && /rodan-client/node_modules/.bin/gulp"
     container_name: rodan-client
     environment:
       - RODAN_CLIENT_DEVELOP_HOST=rodan-client
     ports:
       - "8081:9002"
     restart: always
+    volumes:
+      - ./rodan-client/rodan-client:/rodan-client
+      - /rodan-client/node_modules
+      - ./rodan-client:/src
   rodan-server:
     build:
       context: ./rodan

--- a/rodan-client/Dockerfile
+++ b/rodan-client/Dockerfile
@@ -16,7 +16,6 @@ RUN yarn install
 ARG DEV_JSPM_GITHUB_AUTH_TOKEN
 RUN cd /rodan-client/node_modules/.bin && ./jspm config registries.github.auth ${DEV_JSPM_GITHUB_AUTH_TOKEN}
 RUN cd /rodan-client/node_modules/.bin && ./jspm install -y
-COPY ./rodan-client /rodan-client
-COPY ./configuration.json /rodan-client/configuration.json
+
 EXPOSE 9002
 CMD /rodan-client/node_modules/.bin/gulp


### PR DESCRIPTION
With the use of docker volume, changes in rodan-client source code will be applied immediately and edits to JS code will trigger hot reload.

Unfortunately, edits to the template HTML files will still need a container restart to take effect.

Closes #9.